### PR TITLE
parseSerialNumber fix for None param

### DIFF
--- a/read_waveplus.py
+++ b/read_waveplus.py
@@ -81,7 +81,7 @@ SamplePeriod = int(sys.argv[2])
 # ====================================
 
 def parseSerialNumber(ManuDataHexStr):
-    if (ManuDataHexStr == "None"):
+    if (ManuDataHexStr == None or ManuDataHexStr == "None"):
         SN = "Unknown"
     else:
         ManuData = bytearray.fromhex(ManuDataHexStr)


### PR DESCRIPTION
Sometimes dev.getValueText() returns None from a device, this would cause an exception in parseSerialNumber and the script will fail. Not sure if it can actually return a string "None", if not then the 2nd part of the "if" expression could be removed.